### PR TITLE
added parentheses to install_dir regex

### DIFF
--- a/src/main/java/com/stirante/lolclient/ClientApi.java
+++ b/src/main/java/com/stirante/lolclient/ClientApi.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 
 public class ClientApi {
 
-    private static final Pattern INSTALL_DIR = Pattern.compile(".+\"--install-directory=([a-zA-Z_0-9- :.\\\\/]+)\".+");
+    private static final Pattern INSTALL_DIR = Pattern.compile(".+\"--install-directory=([()a-zA-Z_0-9- :.\\\\/]+)\".+");
     private static final Pattern PORT = Pattern.compile(".+--app-port=([0-9]+).+");
     private static final Gson GSON = new GsonBuilder().create();
 


### PR DESCRIPTION
This fixes a bug where install_dir cannot be found when it resides under, for example, "Program Files (x86)".