### PR TITLE
Catch NullPointerException in isAuthorized method

### DIFF
--- a/src/main/java/com/stirante/lolclient/ClientApi.java
+++ b/src/main/java/com/stirante/lolclient/ClientApi.java
@@ -510,7 +510,7 @@ public class ClientApi {
     public boolean isAuthorized() throws IOException {
         try {
             return executeGet("/lol-summoner/v1/current-summoner", LolSummonerSummoner.class).accountId > 0;
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException | NullPointerException e) {
             return false;
         }
     }


### PR DESCRIPTION
Added NullPointerException in the try-catch block of the isAuthorized method, because I often get the error if I call the function in a ClientConnectionListener.