### PR TITLE
Preliminary support for lockfile resolving for clients running macOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.stirante</groupId>
     <artifactId>lol-client-java-api</artifactId>
-    <version>1.2.8-SNAPSHOT</version>
+    <version>1.2.9-SNAPSHOT</version>
     <name>lol-client-java-api</name>
     <description>Simple library which provides access to internal League of Legends Client API.</description>
     <url>https://github.com/stirante/lol-client-java-api</url>

--- a/src/main/java/com/stirante/lolclient/PSProcessWatcher.java
+++ b/src/main/java/com/stirante/lolclient/PSProcessWatcher.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class PSProcessWatcher extends ProcessWatcher {
 
+    private static final String MAC_OS_X = "Mac OS X";
     private static final Logger logger = LoggerFactory.getLogger(PSProcessWatcher.class);
 
     @Override
@@ -38,7 +39,7 @@ public class PSProcessWatcher extends ProcessWatcher {
 
     @Override
     public CompletableFuture<Boolean> isApplicable() {
-        if (System.getProperty("os.name").startsWith("Windows")) {
+        if (System.getProperty("os.name").startsWith("Windows") || System.getProperty("os.name").startsWith(MAC_OS_X)) {
             logger.debug("ProcessWatcher is not applicable - Windows");
             return CompletableFuture.completedFuture(false);
         }

--- a/src/main/java/com/stirante/lolclient/ProcessWatcher.java
+++ b/src/main/java/com/stirante/lolclient/ProcessWatcher.java
@@ -1,5 +1,6 @@
 package com.stirante.lolclient;
 
+import com.stirante.lolclient.watchers.MacOSProcessWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +20,7 @@ public abstract class ProcessWatcher {
         register(new PSProcessWatcher());
         register(new WMICProcessWatcher());
         register(new PowershellProcessWatcher());
+        register(new MacOSProcessWatcher());
     }
 
     public static void register(ProcessWatcher processWatcher) {

--- a/src/main/java/com/stirante/lolclient/watchers/MacOSProcessWatcher.java
+++ b/src/main/java/com/stirante/lolclient/watchers/MacOSProcessWatcher.java
@@ -1,0 +1,69 @@
+package com.stirante.lolclient.watchers;
+
+import com.stirante.lolclient.ProcessWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MacOSProcessWatcher extends ProcessWatcher {
+
+    private static final String MAC_OS_X = "Mac OS X";
+    private static final Pattern INSTALL_DIRECTORY_PATTERN = Pattern.compile("(--install-directory=)([a-zA-Z./\\s]*)", Pattern.CASE_INSENSITIVE);
+    private static final String INSTALL_DIRECTORY = "--install-directory=";
+    private static final String LEAGUE_CLIENT_UX_PROCESS_NAME = "LeagueClientUx";
+    private static final String LEAGUE_CLIENT_EXECUTABLE_POSTFIX = "/LeagueClient.app";
+    private static final String[] LOOKUP_COMMANDS = new String[]{"/bin/sh", "-c", "ps x -o args | grep 'LeagueClientUx'"};
+    private static final Logger logger = LoggerFactory.getLogger(MacOSProcessWatcher.class);
+
+    /**
+     * This method is used to get the installation directory of the League of Legends client.
+     * It also contains the path of the executable.
+     *
+     * @return The installation directory of the League of Legends client.
+     * @throws IOException If the process fails to execute.
+     */
+    @Override
+    public CompletableFuture<String> getInstallDirectory() throws IOException {
+        Process process = Runtime.getRuntime().exec(LOOKUP_COMMANDS);
+        InputStream processInputStream = process.getInputStream();
+        Scanner scanner = new Scanner(processInputStream);
+
+        while (scanner.hasNextLine()) {
+            String nextLine = scanner.nextLine();
+            if (nextLine.contains(LEAGUE_CLIENT_UX_PROCESS_NAME) && nextLine.contains(INSTALL_DIRECTORY)) {
+                Matcher installDirectoryPatternMatcher = INSTALL_DIRECTORY_PATTERN.matcher(nextLine);
+                if (installDirectoryPatternMatcher.find()) {
+                    return CompletableFuture.completedFuture(installDirectoryPatternMatcher.group(2).trim() + LEAGUE_CLIENT_EXECUTABLE_POSTFIX);
+                }
+            }
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isApplicable() {
+        if (System.getProperty("os.name").contains(MAC_OS_X)) {
+            logger.debug("MacOSProcessWatcher is applicable for the current system.");
+            return CompletableFuture.completedFuture(true);
+        }
+        logger.debug("MacOSProcessWatcher is not applicable for the current system.");
+        return CompletableFuture.completedFuture(false);
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/src/main/java/examples/SkinListExample.java
+++ b/src/main/java/examples/SkinListExample.java
@@ -37,11 +37,11 @@ public class SkinListExample {
                     for (LolChampionsCollectionsChampion champion : champions) {
                         if (champion.ownership.owned) {
                             System.out.println(champion.name + " purchased on " +
-                                    FORMATTER.format(new Date(champion.ownership.rental.purchaseDate)));
+                                    FORMATTER.format(new Date(champion.ownership.rental.purchaseDate.longValue())));
                             for (LolChampionsCollectionsChampionSkin skin : champion.skins) {
                                 if (!skin.isBase && skin.ownership.owned) {
                                     System.out.println("\t" + skin.name + " purchased on " +
-                                            FORMATTER.format(new Date(skin.ownership.rental.purchaseDate)));
+                                            FORMATTER.format(new Date(skin.ownership.rental.purchaseDate.longValue())));
                                 }
                             }
                         }

--- a/src/main/java/generated/LolChampionsCollectionsChampion.java
+++ b/src/main/java/generated/LolChampionsCollectionsChampion.java
@@ -1,5 +1,6 @@
 package generated;
 
+import java.math.BigInteger;
 import java.util.List;
 
 public class LolChampionsCollectionsChampion {
@@ -17,7 +18,7 @@ public class LolChampionsCollectionsChampion {
 	public String name;
 	public LolChampionsCollectionsOwnership ownership;
 	public LolChampionsCollectionsChampionSpell passive;
-	public Long purchased;
+	public BigInteger purchased;
 	public Boolean rankedPlayEnabled;
 	public List<String> roles;
 	public List<LolChampionsCollectionsChampionSkin> skins;

--- a/src/main/java/generated/LolChampionsCollectionsRental.java
+++ b/src/main/java/generated/LolChampionsCollectionsRental.java
@@ -1,9 +1,11 @@
 package generated;
 
+import java.math.BigInteger;
+
 public class LolChampionsCollectionsRental {
 
 	public Long endDate;
-	public Long purchaseDate;
+	public BigInteger purchaseDate;
 	public Boolean rented;
 	public Integer winCountRemaining;
 


### PR DESCRIPTION
Hey! 👋

I have not seen any guides here about the format of PRs. Let me know if I missed something.

### Brief

This PR add preliminary support for LoL clients running macOS. The implementation is similar to the PSProcessWatcher, however due to some macOS quirkiness, some adjustments were made to accommodate proper implementation. 

* A regex match has to be made in order to resolve the install directory of the client. The location of the `LEAGUE_CLIENT_EXECUTABLE_POSTFIX` inside the package is constant and the user is unable to modify this path. This is also where the inside the folder where the lockfile resides.
* We had to append the `LEAGUE_CLIENT_EXECUTABLE_POSTFIX` after finding the path with the regex due to the common implementation of the lockfile resolver code in the ClientApi class.
* I also excluded the PSProcessWatcher from running under macOS

### ⚠️ Most likely a breaking change with future versions:
I have noticed while testing the process watcher, that when I started listing the skins available on my account, I started receiving purchaseDate values in the response JSONs larger and Long.MAX_VALUE so I switched to using BigInteger. Not sure if there is a more proper way to handle this or if this issue even came up with other users of the library.