### PR TITLE
Long limit Hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.stirante</groupId>
     <artifactId>lol-client-java-api</artifactId>
-    <version>1.2.9-SNAPSHOT</version>
+    <version>1.2.10-SNAPSHOT</version>
     <name>lol-client-java-api</name>
     <description>Simple library which provides access to internal League of Legends Client API.</description>
     <url>https://github.com/stirante/lol-client-java-api</url>

--- a/src/main/java/generated/LolChampSelectLegacyChampSelectPlayerSelection.java
+++ b/src/main/java/generated/LolChampSelectLegacyChampSelectPlayerSelection.java
@@ -1,5 +1,8 @@
 package generated;
 
+import java.math.BigInteger;
+
+@SuppressWarnings("unused")
 public class LolChampSelectLegacyChampSelectPlayerSelection {
 
 	public String assignedPosition;
@@ -8,8 +11,8 @@ public class LolChampSelectLegacyChampSelectPlayerSelection {
 	public Integer championPickIntent;
 	public String playerType;
 	public Integer selectedSkinId;
-	public Long spell1Id;
-	public Long spell2Id;
+	public BigInteger spell1Id;
+	public BigInteger spell2Id;
 	public Long summonerId;
 	public Integer team;
 	public Long wardSkinId;


### PR DESCRIPTION
## Long limit Hotfix
This solves #34 issue with the proposed solution: swapping the Long field with a BigInteger

### Impacts
Jackson supports automatic mapping to a BigInteger which solves the problem of the field being too short to be mapped.

- Swapped `LolChampSelectLegacyChampSelectPlayerSelection#spell1Id` and `spell2Id` `Long` type by `BigInteger`.
- Bumped pom.xml version.

### Reviewers please consider:
- This might impact the automatic generation of the class and will be overridden if the process is run in the future.
- Only manual test was executed. No automatic Testing (UT) has been introduced, do we want this to be included in the `test`ing packages?

Please let me know of any concerns, comments, or improvements to the PR.
Thanks to @stirante for the help!