### PR TITLE
RIOT API Account Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Snapshots of all the latest changes are available in my personal nexus repositor
 <dependency>
     <groupId>com.stirante</groupId>
     <artifactId>lol-client-java-api</artifactId>
-    <version>1.2.11-SNAPSHOT</version>
+    <version>1.2.12-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.stirante</groupId>
     <artifactId>lol-client-java-api</artifactId>
-    <version>1.2.11-SNAPSHOT</version>
+    <version>1.2.12-SNAPSHOT</version>
     <name>lol-client-java-api</name>
     <description>Simple library which provides access to internal League of Legends Client API.</description>
     <url>https://github.com/stirante/lol-client-java-api</url>

--- a/src/main/java/generated/LolSummonerSummoner.java
+++ b/src/main/java/generated/LolSummonerSummoner.java
@@ -1,9 +1,14 @@
 package generated;
 
+/**
+ * League Client endpoint `/lol-summoner/v1/current-summoner` response.
+ */
+@SuppressWarnings("unused")
 public class LolSummonerSummoner {
 
 	public Long accountId;
 	public String displayName;
+	public String gameName;
 	public String internalName;
 	public Boolean nameChangeFlag;
 	public Integer percentCompleteForNextLevel;
@@ -13,6 +18,7 @@ public class LolSummonerSummoner {
 	public LolSummonerSummonerRerollPoints rerollPoints;
 	public Long summonerId;
 	public Integer summonerLevel;
+	public String tagLine;
 	public Boolean unnamed;
 	public Long xpSinceLastLevel;
 	public Long xpUntilNextLevel;


### PR DESCRIPTION
## RIOT API Account Support

League Client is now providing new RIOT API Account information in the endpoint `/lol-summoner/v1/current-summoner` call response.
This PR adds support for processing that information on the [`LolSummonerSummoner`](https://github.com/stirante/lol-client-java-api/blob/master/src/main/java/generated/LolSummonerSummoner.java) entity; specifically 2 important elements GameName and Tag.

---------------------

- Summoner names were removed on November 20th 2023. League of Legends will now use **Riot ID**s in their place.
- Summoner names have been transitioned out of the API responses starting April 8th 2024.
- Use Account-V1 by gameName/tagLine as a replacement for Summoner-V4 by-name endpoint. [https://developer.riotgames.com/apis#account-v1/GET_getByRiotId](https://developer.riotgames.com/apis#account-v1/GET_getByRiotId)
- You can use the PUUID from that endpoint with Summoner-V4 by-puuid to get the same summoner information as you were getting before https://developer.riotgames.com/apis#summoner-v4/GET_getByPUUID

*You can read more about the transition here: https://www.riotgames.com/en/DevRel/summoner-names-to-riot-id*


-------------------
As you can see the old summoner name is still provided in the entity and the reponse of the endpoint but the new information is now being provided by the client, this will just add support for handling that information.